### PR TITLE
Improved self-host NGINX config example

### DIFF
--- a/source/selfHosted/hostItYourself.rst
+++ b/source/selfHosted/hostItYourself.rst
@@ -368,9 +368,25 @@ Your NGINX-Config may look similar to this.
         set $gbridge_port 8080
 
         location /gbridge/gapi/ {
-            #public access to the account dashboard is disabled for security reasons
+            # Public access to the account dashboard is disabled for security reasons
             proxy_pass http://$gbridge_host:$gbridge_port/gapi/;
+            # The following variables are set so Apache knows the real hostname and can redirect and resolve urls accordingly.
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Host $server_name;
         }
+        
+        # Uncomment to allow access to the web interface.
+        # When using this, uncomment the block above and adjust the URLs in Google's configuration to remove the /gbridge/ prefix.
+        # location / {
+        #    proxy_pass http://$gbridge_host:$gbridge_port/;
+        #    # The following variables are set so Apache knows the real hostname and can redirect and resolve urls accordingly.
+        #    proxy_set_header Host $host;
+        #    proxy_set_header X-Real-IP $remote_addr;
+        #    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        #    proxy_set_header X-Forwarded-Host $server_name;
+        # }
     }
 
 Test it


### PR DESCRIPTION
While evaluating the viability of a self-hosted instance of gBridge, I came across this minor thing with the documentation.

Adding these headers allows the docker Apache to know the actual hostname and origin IP.
This is required for the proper redirection of the browser, such as when logging in to the web interface.

I'd also like to mention the screenshots are out of date, but they are still easy enough to follow along with that I don't think it's worth the effort to update them.

Kind regards,
Dries Kennes

EDIT: This doesn't completely fix the situation if HTTPS is used, because it seems the web interface/apache is hardcoded to generate HTTP urls. 

This configuration allows logging in via the web interface:
~~(Logging in via account linking is still an issue.)~~

```nginx
    # gBridge
    location / {
        proxy_pass http://localhost:8080/;
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Host $server_name;
        proxy_set_header X-Forwarded-Proto $scheme;
        proxy_redirect   http://localhost:8080 https://$host;
        proxy_set_header Accept-Encoding "";
        sub_filter http:// https://;
        sub_filter_once off;
    }
```